### PR TITLE
Fixed spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All requirements come preinstalled on Kali Linux, to run on other flavors or Mac
 just make sure curl(owa & lync) and rpcclient(smb) are installed using apt-get or brew.
 
 ```
-rpclient
+rpcclient
 curl
 ```
 


### PR DESCRIPTION
`README.md` says the `rpclient` tool is required, but it should be `rpcclient`. This commit fixes the spelling mistake.